### PR TITLE
Fixed a runtime exception when running via source

### DIFF
--- a/src/view_controls/view.py
+++ b/src/view_controls/view.py
@@ -269,7 +269,7 @@ class DrawingTool(object):
         # Empty the previous drawn items list
         self.drawn_items[:] = []
         # Build the list of items to display
-        items_to_flow = [x for x in self.state.item_list if self.show_item(x)]
+        items_to_flow = [x for x in self.state.item_list if self.show_item(x)] if self.state is not None else []
         n_items_to_flow = len(items_to_flow)
 
         if n_items_to_flow == 0:


### PR DESCRIPTION
When running via source (I did not attempt to build the project),
it exited with the following exception:

```
Traceback (most recent call last):
    File ".\item_tracker.py", line 229, in main
        rt.run()
    File ".\item_tracker.py", line 80, in run
        event_result = drawing_tool.handle_events()
    File ".\view_controls\view.py", line 116, in handle_events
        self.__reflow()
    File ".\view_controls\view.py", line 272, in __reflow
        items_to_flow = [x for x in self.state.item_list if self.show_item(x)]
AttributeError: 'NoneType' object has no attribute 'item_list'
```

The simple fix in this commit made everything run correctly.

Environment details:
Windows 10
Python 2.7.11 (Anaconda 4.0.0 64-bit))
Pygame 1.9.2a0 (from https://conda.binstar.org/krisvanneste/win-64/pygame-1.9.2a0-py27_0.tar.bz2)
